### PR TITLE
Fix ncurses compilation error on MacOS

### DIFF
--- a/draw.c
+++ b/draw.c
@@ -1,5 +1,6 @@
-
 #include "draw.h"
+#include <ncurses.h>
+#define _XOPEN_SOURCE_EXTENDED 1
 
 static int selectedStyle = FANCY;
 


### PR DESCRIPTION
Error:

`draw.c:290:5: error: call to undeclared function 'addwstr'`

Solution:
1. Add these lines
```
#include <ncurses.h>
#define _XOPEN_SOURCE_EXTENDED 1
```
2. The command "make" causes a problem. Instead you should use this:
`cc -w main.c autopilot.c xymap.c structs.c snake.c draw.c -lncurses -o sssnake`