### PR TITLE
Fix build and install on macOS (Apple Silicon & Intel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ yum install ncurses-devel        #RHEL/CentOS/Fedora and Rocky Linux/AlmaLinux
 pacman -S ncurses                #Arch Linux
 zypper install ncurses-devel     #OpenSUSE 
 xbps-install -S ncurses-devel    #Void linux
+brew install ncurses             #MacOS
 ```
 
 With that you can just do:
@@ -20,7 +21,7 @@ With that you can just do:
 git clone https://github.com/AngelJumbo/sssnake.git
 cd sssnake
 make
-make install
+sudo make install
 ```
 
 

--- a/makefile
+++ b/makefile
@@ -1,12 +1,22 @@
 PREFIX = /usr/local
 MANDIR = $(PREFIX)/share/man
+NCURSES_FLAGS = $(shell ncursesw5-config --cflags --libs 2>/dev/null)
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    ifneq ($(wildcard /opt/homebrew/opt/ncurses),)
+        HB_PATH = /opt/homebrew/opt/ncurses
+    else
+        HB_PATH = /usr/local/opt/ncurses
+    endif
+    NCURSES_FLAGS = -I$(HB_PATH)/include -L$(HB_PATH)/lib -D_XOPEN_SOURCE_EXTENDED
+endif
 
 sssnake: main.c autopilot.c xymap.c structs.c snake.c draw.c 
-	$(CC) -w $(ncursesw5-config --cflags --libs) main.c autopilot.c xymap.c structs.c snake.c draw.c -lncursesw -o sssnake
+	$(CC) -w $(NCURSES_FLAGS) main.c autopilot.c xymap.c structs.c snake.c draw.c -lncursesw -o sssnake
 
 debug: main.c autopilot.c xymap.c structs.c snake.c draw.c 
-	$(CC) -w $(ncursesw5-config --cflags --libs) -Wall -g main.c autopilot.c xymap.c structs.c snake.c draw.c -lncursesw -o sssnake
-
+	$(CC) -w $(NCURSES_FLAGS) -Wall -g main.c autopilot.c xymap.c structs.c snake.c draw.c -lncursesw -o sssnake
 
 .PHONY: genman
 genman:
@@ -18,11 +28,12 @@ clean:
 
 .PHONY: install
 install: sssnake
-	install					-D sssnake 					$(DESTDIR)$(PREFIX)/bin/sssnake
-	install	-m 644	-D ./docs/sssnake.1	$(DESTDIR)$(MANDIR)/man1/sssnake.1
+	mkdir -p $(DESTDIR)$(PREFIX)/bin
+	mkdir -p $(DESTDIR)$(MANDIR)/man1
+	install -m 755 sssnake $(DESTDIR)$(PREFIX)/bin/sssnake
+	install -m 644 ./docs/sssnake.1 $(DESTDIR)$(MANDIR)/man1/sssnake.1
 
 .PHONY: uninstall
 uninstall:
 	$(RM) $(DESTDIR)$(PREFIX)/bin/sssnake
 	$(RM) $(DESTDIR)$(MANDIR)/man1/sssnake.1
-


### PR DESCRIPTION
This PR updates Makefile to fix ncurses-related build errors on MacOS 

Changes:
1. Detect Platform 
2. Specifies Homebrew ncurses library path
3. add flag `-D_XOPEN_SOURCE_EXTENDED` to fix the `addwstr undeclared` error on macOS.
4. Replace `install -D` option with `mkdir -p` for BSD compatibility
5. Updated README for MacOS prerequisites 