### PR TITLE
Ensure addwstr is defined

### DIFF
--- a/draw.h
+++ b/draw.h
@@ -3,7 +3,8 @@
 
 #include "snake.h"
 #include "structs.h"
-#include <curses.h>
+#define _XOPEN_SOURCE_EXTENDED 1
+#include <ncursesw/curses.h>
 #include <locale.h>
 #include <wchar.h>
 


### PR DESCRIPTION
Ensure `addwstr` is defined
to make it compile with gcc14+

gcc13 with `-Wall` would issue a warning about
`implicit declaration of function ‘addwstr’;`
and gcc14 and later turned that into an error.